### PR TITLE
clean up and use behaviours

### DIFF
--- a/paper-radio-group.html
+++ b/paper-radio-group.html
@@ -9,7 +9,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 -->
 
 <link rel="import" href="../polymer/polymer.html">
-<link rel="import" href="../iron-selector/iron-selector.html">
+<link rel="import" href="../iron-selector/iron-selectable.html">
 <link rel="import" href="../paper-radio-button/paper-radio-button.html">
 <link rel="import" href="../iron-a11y-keys-behavior/iron-a11y-keys-behavior.html">
 
@@ -42,16 +42,13 @@ information about `paper-radio-button`.
       display: inline-block;
     }
 
-    iron-selector ::content > * {
+    :host ::content > * {
       padding: 12px;
     }
   </style>
 
   <template>
-    <iron-selector selected="{{selected}}" attr-for-selected="name"
-        selectable="paper-radio-button">
       <content id="items" select="*"></content>
-    </iron-selector>
   </template>
 
 </dom-module>
@@ -61,7 +58,8 @@ information about `paper-radio-button`.
     is: 'paper-radio-group',
 
     behaviors: [
-      Polymer.IronA11yKeysBehavior
+      Polymer.IronA11yKeysBehavior,
+      Polymer.IronSelectableBehavior
     ],
 
     hostAttributes: {
@@ -71,116 +69,74 @@ information about `paper-radio-button`.
 
     properties: {
       /**
-       * Fired when the selected element changes to user interaction.
-       *
-       * @event paper-radio-group-changed
+       * Overriden from Polymer.IronSelectableBehavior
        */
+      attrForSelected: {
+        value: 'name'
+      },
 
       /**
-       * Gets or sets the selected element. Use the `name` attribute of the
-       * <paper-radio-button> that should be selected.
-       *
-       * @attribute selected
-       * @type String
-       * @default null
+       * Overriden from Polymer.IronSelectableBehavior
        */
-
-      selected: {
-        type: String,
-        value: null,
-        notify: true,
-        reflectToAttribute: true,
-        observer: "_selectedChanged"
+      selectedAttribute: {
+        value: 'checked'
       }
     },
 
     keyBindings: {
-      'left up': '_selectPrevious',
-      'right down': '_selectNext',
-    },
-
-    _selectedChanged: function() {
-      // TODO: This only needs to be async while a domReady event is unavailable.
-      this.async(function() {
-        this._selectIndex(this._valueToIndex(this.items, this.selected));
-        this.fire('paper-radio-group-changed');
-      });
-    },
-
-    _selectNext: function() {
-      this.selected = this._nextNode();
-    },
-
-    _selectPrevious: function() {
-      this.selected = this._previousNode();
+      'left up': 'selectPrevious',
+      'right down': 'selectNext',
     },
 
     /**
-     * Returns an array of all items.
-     *
-     * @property items
-     * @type array
+     * Selects the given value.
      */
-    get items() {
-      return Polymer.dom(this.$.items).getDistributedNodes();
-    },
+     select: function(value) {
+      if (this.selected) {
+        var oldItem = this._valueToItem(this.selected);
 
-    _nextNode: function() {
-      var items = this.items;
-      var index = this._selectedIndex;
-      var newIndex = index;
-      do {
-        newIndex = (newIndex + 1) % items.length;
-        if (newIndex === index) {
-          break;
+        // Do not allow unchecking the selected item.
+        if (this.selected == value) {
+          oldItem.checked = true;
+          return;
         }
-      } while (items[newIndex].disabled);
-      return this._valueForNode(items[newIndex]);
-    },
 
-    _previousNode: function() {
-      var items = this.items;
-      var index = this._selectedIndex;
-      var newIndex = index;
-      do {
-        newIndex = (newIndex || items.length) - 1;
-        if (newIndex === index) {
-          break;
-        }
-      } while (items[newIndex].disabled);
-      return this._valueForNode(items[newIndex]);
-    },
-
-    _selectIndex: function(index) {
-      if (index == this._selectedIndex)
-        return;
-
-      var nodes = this.items;
-
-      // If there was a previously selected node, deselect it.
-      if (nodes[this._selectedIndex]) {
-        nodes[this._selectedIndex].checked = false;
+        if (oldItem)
+          oldItem.checked = false;
       }
 
-      // Select a new node.
-      nodes[index].checked = true;
-      nodes[index].focus();
-      this._selectedIndex = index;
+      Polymer.IronSelectableBehavior.select.apply(this, [value]);
+      this.fire('paper-radio-group-changed');
     },
 
-    _valueForNode: function(node) {
-      return node["name"] || node.getAttribute("name");
+    /**
+     * Selects the previous item. If the previous item is disabled, then it is
+     * skipped, and its previous item is selected
+     */
+    selectPrevious: function() {
+      var length = this.items.length;
+      var newIndex = Number(this._valueToIndex(this.selected));
+
+      do {
+        newIndex = (newIndex - 1 + length) % length;
+      } while (this.items[newIndex].disabled)
+
+      this.select(this._indexToValue(newIndex));
     },
 
-    // Finds an item with value == |value| and return its index.
-    _valueToIndex: function(items, value) {
-      for (var index = 0, node; (node = items[index]); index++) {
-        if (this._valueForNode(node) == value) {
-          return index;
-        }
-      }
-      // If no item found, the value itself is probably the index.
-      return value;
-    }
+    /**
+     * Selects the next item. If the next item is disabled, then it is
+     * skipped, and its nexy item is selected
+     */
+    selectNext: function() {
+      var length = this.items.length;
+      var newIndex = Number(this._valueToIndex(this.selected));
+
+      do {
+        newIndex = (newIndex + 1 + length) % length;
+      } while (this.items[newIndex].disabled)
+
+      this.select(this._indexToValue(newIndex));
+    },
   });
 </script>

--- a/test/basic.html
+++ b/test/basic.html
@@ -57,110 +57,114 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     <script>
       suite('defaults', function() {
-        var g1;
-        var g2;
-        var g3;
-
-        setup(function() {
-          g1 = fixture('NoSelection');
-          g2 = fixture('WithSelection');
-          g3 = fixture('WithDisabled');
-        });
+        var LEFT_ARROW = 37;
+        var RIGHT_ARROW = 39;
 
         test('group can have no selection', function () {
-          expect(g1.selected).to.not.be.ok;
-          var items = g1.items;
+          var g = fixture('NoSelection');
+          expect(g.selected).to.not.be.ok;
+          var items = g.items;
           expect(items.length).to.be.equal(3);
           expect(items[0].checked).to.be.equal(false);
           expect(items[1].checked).to.be.equal(false);
           expect(items[2].checked).to.be.equal(false);
         });
 
-        test('group can have a selection', function (done) {
-          expect(g2.selected).to.be.ok;
-          var items = g2.items;
+        test('group can have a selection', function () {
+          var g = fixture('WithSelection');
+          expect(g.selected).to.be.ok;
+          var items = g.items;
           expect(items.length).to.be.equal(3);
 
-          g2.addEventListener('paper-radio-group-changed', function () {
-            expect(items[0].checked).to.be.equal(true);
-            expect(items[1].checked).to.be.equal(false);
-            expect(items[2].checked).to.be.equal(false);
-
-            expect(items[0].getAttribute('name')).to.be.equal(g2.selected);
-            done();
-          });
+          expect(items[0].checked).to.be.equal(true);
+          expect(items[1].checked).to.be.equal(false);
+          expect(items[2].checked).to.be.equal(false);
+          expect(items[0].getAttribute('name')).to.be.equal(g.selected);
         });
 
         test('right arrow advances the selection', function (done) {
-          debugger
-          var items = g2.items;
+          var g = fixture('WithSelection');
+          var items = g.items;
 
-          // Initially, the first item is checked.
-          var expectedCheckedItem = 0;
-          g2.addEventListener('paper-radio-group-changed', function () {
-            expect(items[expectedCheckedItem].checked).to.be.equal(true);
+          expect(items[0].checked).to.be.equal(true);
 
-            // Right arrow should go to the next item.
-            expectedCheckedItem = 1;
-            var event = new CustomEvent('keydown');
-            event.keyCode = event.code = 39;
-            g2.dispatchEvent(event);
-
+          g.addEventListener('paper-radio-group-changed', function () {
+            expect(items[0].checked).to.be.equal(false);
+            expect(items[1].checked).to.be.equal(true);
+            expect(items[2].checked).to.be.equal(false);
             done();
           });
+
+          MockInteractions.keyDownOn(g, RIGHT_ARROW);
         });
 
         test('left arrow reverses the selection', function (done) {
-          var items = g2.items;
+          var g = fixture('WithSelection');
+          var items = g.items;
 
-          // Initially, the first item is checked.
-          var expectedCheckedItem = 0;
-          g2.addEventListener('paper-radio-group-changed', function () {
-            expect(items[expectedCheckedItem].checked).to.be.equal(true);
+          expect(items[0].checked).to.be.equal(true);
 
-            // Left arrow should go to the last item.
-            expectedCheckedItem = 2;
-            var event = new CustomEvent('keydown');
-            event.keyCode = event.code = 37;
-            g2.dispatchEvent(event);
-
+          g.addEventListener('paper-radio-group-changed', function () {
+            expect(items[0].checked).to.be.equal(false);
+            expect(items[1].checked).to.be.equal(false);
+            expect(items[2].checked).to.be.equal(true);
             done();
           });
+          MockInteractions.keyDownOn(g, LEFT_ARROW);
         });
 
         test('selection should skip disabled items', function (done) {
-          var items = g3.items;
+          var g = fixture('WithDisabled');
+          var items = g.items;
 
-          // Initially, the first item is checked.
-          var expectedCheckedItem = 0;
-          g3.addEventListener('paper-radio-group-changed', function () {
-            expect(items[expectedCheckedItem].checked).to.be.equal(true);
+          expect(items[0].checked).to.be.equal(true);
 
-            // Right arrow should go to the last item, since the second item is
-            // disabled.
-            expectedCheckedItem = 2;
-            var event = new CustomEvent('keydown');
-            event.keyCode = event.code = 39;
-            g3.dispatchEvent(event);
-
+          g.addEventListener('paper-radio-group-changed', function () {
+            expect(items[0].checked).to.be.equal(false);
+            expect(items[1].checked).to.be.equal(false);
+            expect(items[2].checked).to.be.equal(true);
             done();
           });
+          MockInteractions.keyDownOn(g, RIGHT_ARROW);
         });
 
         test('clicking should change the selection', function (done) {
-          var items = g2.items;
+          var g = fixture('WithSelection');
+          var items = g.items;
 
-          // Initially, the first item is checked.
-          var expectedCheckedItem = 0;
-          g3.addEventListener('paper-radio-group-changed', function () {
-            expect(items[expectedCheckedItem].checked).to.be.equal(true);
+          expect(items[0].checked).to.be.equal(true);
 
-            expectedCheckedItem = 1;
-            MockInteractions.down(items[1]);
-
+          g.addEventListener('paper-radio-group-changed', function () {
+            expect(items[0].checked).to.be.equal(false);
+            expect(items[1].checked).to.be.equal(true);
+            expect(items[2].checked).to.be.equal(false);
             done();
           });
+
+          MockInteractions.tap(items[1]);
         });
+
+        test('clicking the selected item should not deselect', function (done) {
+          var g = fixture('WithSelection');
+          var items = g.items;
+
+          expect(items[0].checked).to.be.equal(true);
+          MockInteractions.tap(items[0]);
+
+          // The selection should not change, but wait for a little bit just
+          // in case it would and an event would be fired.
+          setTimeout(function() {
+            try {
+              expect(items[0].checked).to.be.equal(true);
+              expect(items[1].checked).to.be.equal(false);
+              expect(items[2].checked).to.be.equal(false);
+              done();
+            } catch (e) {
+              done(e)
+            }
+          }, 200);
+        });
+
       });
     </script>
   </body>


### PR DESCRIPTION
This element got ported before `iron-selectable` the behaviour came around, so it's been needing some TLC since then.

I've also:
- fixed https://github.com/PolymerElements/paper-radio-button/issues/28, https://github.com/PolymerElements/paper-radio-group/issues/13, and prevented deselecting the active, selected item
- removed the initial `paper-radio-group-changed` event that fired when setting the initial `selected` value. I don't think it makes sense, but I am not opposed to adding it back.
- cleaned up the tests to make more sense out of the `async` call in `ready()` (which is needed to check a radio-button after it's been added to the dom)
- cleaned up all the copy pasta that already lives happily in `iron-selectable`

/cc @cdata @morethanreal 