### PR TITLE
Only use paper-radio-buttons for selection

### DIFF
--- a/paper-radio-group.html
+++ b/paper-radio-group.html
@@ -82,6 +82,14 @@ information about `paper-radio-button`.
       selectedAttribute: {
         type: String,
         value: 'checked'
+      },
+
+      /**
+       * Overriden from Polymer.IronSelectableBehavior
+       */
+      selectable: {
+        type: String,
+        value: 'paper-radio-button'
       }
     },
 


### PR DESCRIPTION
Fixes https://github.com/PolymerElements/paper-radio-group/issues/21 by skipping all non-`paper-radio-buttons` that might be present.

@cdata PTAL. Thanks!