### PR TITLE
Remove .html suffix from link to paper-radio-button

### DIFF
--- a/paper-radio-group.html
+++ b/paper-radio-group.html
@@ -27,7 +27,7 @@ Example:
       <paper-radio-button name="large">Large</paper-radio-button>
     </paper-radio-group>
 
-See <a href="paper-radio-button.html">paper-radio-button</a> for more
+See <a href="paper-radio-button">paper-radio-button</a> for more
 information about `paper-radio-button`.
 
 @group Paper Elements


### PR DESCRIPTION
With the .html suffix the link leads to nowhere. Try clicking it here https://elements.polymer-project.org/elements/paper-radio-group. Inspect the link, remove '.html' and click it again.