### PR TITLE
add attribute to allow empty selections, fix docs

### DIFF
--- a/paper-radio-group.html
+++ b/paper-radio-group.html
@@ -14,14 +14,25 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="../iron-a11y-keys-behavior/iron-a11y-keys-behavior.html">
 
 <!--
-`paper-radio-group` allows user to select only one radio button from a set.
+`paper-radio-group` allows user to select at most one radio button from a set.
 Checking one radio button that belongs to a radio group unchecks any
 previously checked radio button within the same group. Use
 `selected` to get or set the selected radio button.
 
+The <paper-radio-buttons> inside the group must have the `name` attribute
+set.
+
 Example:
 
     <paper-radio-group selected="small">
+      <paper-radio-button name="small">Small</paper-radio-button>
+      <paper-radio-button name="medium">Medium</paper-radio-button>
+      <paper-radio-button name="large">Large</paper-radio-button>
+    </paper-radio-group>
+
+Radio-button-groups can be made optional, and allow zero buttons to be selected:
+
+    <paper-radio-group selected="small" allow-empty-selection>
       <paper-radio-button name="small">Small</paper-radio-button>
       <paper-radio-button name="medium">Medium</paper-radio-button>
       <paper-radio-button name="large">Large</paper-radio-button>
@@ -69,6 +80,12 @@ information about `paper-radio-button`.
 
     properties: {
       /**
+       * Fired when the radio group selection changes.
+       *
+       * @event paper-radio-group-changed
+       */
+
+      /**
        * Overriden from Polymer.IronSelectableBehavior
        */
       attrForSelected: {
@@ -90,6 +107,14 @@ information about `paper-radio-button`.
       selectable: {
         type: String,
         value: 'paper-radio-button'
+      },
+
+      /**
+       * If true, radio-buttons can be deselected
+       */
+      allowEmptySelection: {
+        type: Boolean,
+        value: false
       }
     },
 
@@ -105,10 +130,16 @@ information about `paper-radio-button`.
       if (this.selected) {
         var oldItem = this._valueToItem(this.selected);
 
-        // Do not allow unchecking the selected item.
         if (this.selected == value) {
-          oldItem.checked = true;
-          return;
+          // If deselecting is allowed we'll have to apply an empty selection.
+          // Otherwise, we should force the selection to stay and make this
+          // action a no-op.
+          if (this.allowEmptySelection) {
+            value = '';
+          } else {
+            oldItem.checked = true;
+            return;
+          }
         }
 
         if (oldItem)

--- a/test/basic.html
+++ b/test/basic.html
@@ -154,15 +154,29 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           // The selection should not change, but wait for a little bit just
           // in case it would and an event would be fired.
           setTimeout(function() {
-            try {
-              expect(items[0].checked).to.be.equal(true);
-              expect(items[1].checked).to.be.equal(false);
-              expect(items[2].checked).to.be.equal(false);
-              done();
-            } catch (e) {
-              done(e)
-            }
-          }, 200);
+            expect(items[0].checked).to.be.equal(true);
+            expect(items[1].checked).to.be.equal(false);
+            expect(items[2].checked).to.be.equal(false);
+            done();
+          }, 1);
+        });
+
+        test('clicking the selected item should deselect if allow-empty-selection is set', function (done) {
+          var g = fixture('WithSelection');
+          g.allowEmptySelection = true;
+          var items = g.items;
+
+          expect(items[0].checked).to.be.equal(true);
+          MockInteractions.tap(items[0]);
+
+          // The selection should not change, but wait for a little bit just
+          // in case it would and an event would be fired.
+          setTimeout(function() {
+            expect(items[0].checked).to.be.equal(false);
+            expect(items[1].checked).to.be.equal(false);
+            expect(items[2].checked).to.be.equal(false);
+            done();
+          }, 1);
         });
 
       });


### PR DESCRIPTION
- adds an `allow-empty-selection` attribute, so that if you really, really want an optional radio button group, you can have one. Fixes https://github.com/PolymerElements/paper-radio-group/issues/14
- add docs for the event that gets fired. Fixes https://github.com/PolymerElements/paper-radio-group/issues/26
- add docs that 'name' is required. Fixes https://github.com/PolymerElements/paper-radio-group/issues/24

@cdata PTAL