### PR TITLE
Fire `iron-activate` when changing values with the keyboard.

### DIFF
--- a/paper-radio-group.html
+++ b/paper-radio-group.html
@@ -163,7 +163,7 @@ information about `paper-radio-button`.
         newIndex = (newIndex - 1 + length) % length;
       } while (this.items[newIndex].disabled)
 
-      this.select(this._indexToValue(newIndex));
+      this._itemActivate(this._indexToValue(newIndex), this.items[newIndex]);
     },
 
     /**
@@ -178,7 +178,7 @@ information about `paper-radio-button`.
         newIndex = (newIndex + 1 + length) % length;
       } while (this.items[newIndex].disabled)
 
-      this.select(this._indexToValue(newIndex));
+      this._itemActivate(this._indexToValue(newIndex), this.items[newIndex]);
     },
   });
 </script>

--- a/test/basic.html
+++ b/test/basic.html
@@ -206,6 +206,37 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           }, 1);
         });
 
+        test('arrow keys cause iron-activate events', function(done) {
+          var g = fixture('WithSelection');
+
+          // Needs to be async since the underlying iron-selector uses observeNodes.
+          Polymer.Base.async(function() {
+            g.items[0].focus();
+
+            var i = 0;
+            g.addEventListener('iron-activate', function() {
+              switch (i++) {
+                case 0:
+                  MockInteractions.pressAndReleaseKeyOn(g, 38);
+                break;
+
+                case 1:
+                  MockInteractions.pressAndReleaseKeyOn(g, 39);
+                break;
+
+                case 2:
+                  MockInteractions.pressAndReleaseKeyOn(g, 40);
+                break;
+
+                default:
+                  done();
+              }
+            });
+
+            MockInteractions.pressAndReleaseKeyOn(g, 37);
+          }, 1);
+        });
+
       });
     </script>
   </body>


### PR DESCRIPTION
Fixes PolymerElements/iron-menu-behavior#37.