### PR TITLE
Prevent "Uncaught TypeError: Cannot set property 'checked' of undefined"

### DIFF
--- a/paper-radio-group.html
+++ b/paper-radio-group.html
@@ -138,7 +138,8 @@ information about `paper-radio-button`.
           if (this.allowEmptySelection) {
             value = '';
           } else {
-            oldItem.checked = true;
+            if (oldItem)
+              oldItem.checked = true;
             return;
           }
         }


### PR DESCRIPTION
This error occurs if the `select` property is set before the related
`paper-radio-button` is rendered. We see this happening from time to
time if radio buttons are generated in a `dom-repeat` section.