### PR TITLE
Basic compatibility with <iron-form>

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,9 +21,11 @@
   "ignore": [],
   "dependencies": {
     "polymer": "Polymer/polymer#^1.1.0",
-    "iron-menu-behavior": "PolymerElements/iron-menu-behavior#^1.1.7"
+    "iron-menu-behavior": "PolymerElements/iron-menu-behavior#^1.1.7",
+    "iron-form-element-behavior": "PolymerElements/iron-form-element-behavior#^1.0.6"
   },
   "devDependencies": {
+    "iron-form": "PolymerElements/iron-form#^1.1.4",
     "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",
     "iron-demo-helpers": "PolymerElements/iron-demo-helpers#^1.0.0",
     "iron-test-helpers": "PolymerElements/iron-test-helpers#^1.0.0",

--- a/paper-radio-group.html
+++ b/paper-radio-group.html
@@ -11,6 +11,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../iron-a11y-keys-behavior/iron-a11y-keys-behavior.html">
 <link rel="import" href="../iron-menu-behavior/iron-menubar-behavior.html">
+<link rel="import" href="../iron-form-element-behavior/iron-form-element-behavior.html">
 <link rel="import" href="../paper-radio-button/paper-radio-button.html">
 
 <!--
@@ -75,7 +76,8 @@ Custom property | Description | Default
     is: 'paper-radio-group',
 
     behaviors: [
-      Polymer.IronMenubarBehavior
+      Polymer.IronMenubarBehavior,
+      Polymer.IronFormElementBehavior
     ],
 
     hostAttributes: {
@@ -120,6 +122,15 @@ Custom property | Description | Default
       allowEmptySelection: {
         type: Boolean,
         value: false
+      },
+
+      /**
+       * Overridden from Polymer.IronFormElementBehavior.
+       */
+      value: {
+        type: String,
+        notify: true,
+        computed: '_computeValueForForm(selected)'
       }
     },
 
@@ -158,6 +169,10 @@ Custom property | Description | Default
 
     _activateFocusedItem: function() {
       this._itemActivate(this._valueForItem(this.focusedItem), this.focusedItem);
+    },
+
+    _computeValueForForm: function(selected) {
+      return selected || null;
     },
 
     _onUpKey: function(event) {

--- a/test/form.html
+++ b/test/form.html
@@ -1,0 +1,55 @@
+<!doctype html>
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <title>paper-radio-group form tests</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+
+    <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+    <script src="../../web-component-tester/browser.js"></script>
+    <script src="../../iron-test-helpers/mock-interactions.js"></script>
+    <link rel="import" href="../../iron-form/iron-form.html">
+    <link rel="import" href="../paper-radio-group.html">
+
+  </head>
+  <body>
+
+    <test-fixture id="FormSerialization">
+      <template>
+        <form is="iron-form">
+          <paper-radio-group name="radioGroup" selected="r1">
+            <paper-radio-button name="r1">r1</paper-radio-button>
+            <paper-radio-button name="r2">r2</paper-radio-button>
+            <paper-radio-button name="r3">r3</paper-radio-button>
+          </paper-radio-group>
+        </form>
+      </template>
+    </test-fixture>
+
+    <script>
+      suite('defaults', function() {
+        test('group in a form should serialize', function (done) {
+          var f = fixture('FormSerialization');
+          var g = f.querySelector("paper-radio-group");
+
+          // Needs to be async since the underlying iron-selector uses observeNodes.
+          Polymer.Base.async(function() {
+            var serialized = f.serialize();
+            expect(g.selected).to.be.equal("r1");
+            expect(serialized.radioGroup).to.be.equal("r1");
+            done();
+          }, 1);
+        });
+      });
+    </script>
+  </body>
+</html>

--- a/test/index.html
+++ b/test/index.html
@@ -16,7 +16,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <script>
       WCT.loadSuites([
         'basic.html',
-        'basic.html?dom=shadow'
+        'basic.html?dom=shadow',
+        'form.html',
+        'form.html?dom=shadow'
       ]);
     </script>
   


### PR DESCRIPTION
This proposed change fixes #58, by adding support for `IronFormElementBehavior`.

The end result is that calls to `<iron-form>.serialize()` return a payload that includes a key for each `paper-radio-group` contained within it (in addition to other fields), where the value at that key is the value of `selected` (or, in other words, the value of `attrForSelected` on the selected item).
- <paper-radio-group> now includes the behavior mentioned above
- in compliance with that behavior, `value` is provided as a synonym of the property `selected`

This is the less invasive option and only attempts to solve #58, not #66. A pull request for that is forthcoming.
