### PR TITLE
Rich compatibility with <iron-form>

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,9 +21,12 @@
   "ignore": [],
   "dependencies": {
     "polymer": "Polymer/polymer#^1.1.0",
-    "iron-menu-behavior": "PolymerElements/iron-menu-behavior#^1.1.7"
+    "iron-menu-behavior": "PolymerElements/iron-menu-behavior#^1.1.7",
+    "iron-form-element-behavior": "PolymerElements/iron-form-element-behavior#^1.0.6",
+    "iron-validatable-behavior": "PolymerElements/iron-validatable-behavior#^1.1.1"
   },
   "devDependencies": {
+    "iron-form": "PolymerElements/iron-form#^1.1.4",
     "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",
     "iron-demo-helpers": "PolymerElements/iron-demo-helpers#^1.0.0",
     "iron-test-helpers": "PolymerElements/iron-test-helpers#^1.0.0",

--- a/paper-radio-group.html
+++ b/paper-radio-group.html
@@ -11,6 +11,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../iron-a11y-keys-behavior/iron-a11y-keys-behavior.html">
 <link rel="import" href="../iron-menu-behavior/iron-menubar-behavior.html">
+<link rel="import" href="../iron-validatable-behavior/iron-validatable-behavior.html">
+<link rel="import" href="../iron-form-element-behavior/iron-form-element-behavior.html">
 <link rel="import" href="../paper-radio-button/paper-radio-button.html">
 
 <!--
@@ -75,7 +77,9 @@ Custom property | Description | Default
     is: 'paper-radio-group',
 
     behaviors: [
-      Polymer.IronMenubarBehavior
+      Polymer.IronMenubarBehavior,
+      Polymer.IronFormElementBehavior,
+      Polymer.IronValidatableBehavior
     ],
 
     hostAttributes: {
@@ -115,11 +119,38 @@ Custom property | Description | Default
       },
 
       /**
+       * Overridden from Polymer.IronFormElementBehavior.
+       */
+      required: {
+        type: Boolean,
+        notify: true,
+        computed: '_computeRequiredForForm(allowEmptySelection)'
+      },
+
+      /**
+       * Overridden from Polymer.IronFormElementBehavior.
+       */
+      value: {
+        type: String,
+        notify: true,
+        computed: '_computeValueForForm(selected)'
+      },
+
+      /**
        * If true, radio-buttons can be deselected
        */
       allowEmptySelection: {
         type: Boolean,
         value: false
+      },
+
+      /**
+       * Overridden from Polymer.IronFormElementBehavior.
+       */
+      value: {
+        type: String,
+        notify: true,
+        computed: '_computeValueForForm(selected)'
       }
     },
 
@@ -160,6 +191,14 @@ Custom property | Description | Default
       this._itemActivate(this._valueForItem(this.focusedItem), this.focusedItem);
     },
 
+    _computeRequiredForForm: function(allowEmptySelection) {
+      return !allowEmptySelection;
+    },
+
+    _computeValueForForm: function(selected) {
+      return selected || null;
+    },
+
     _onUpKey: function(event) {
       this._focusPrevious();
       event.preventDefault();
@@ -180,6 +219,20 @@ Custom property | Description | Default
     _onRightKey: function(event) {
       Polymer.IronMenubarBehaviorImpl._onRightKey.apply(this, arguments);
       this._activateFocusedItem();
+    },
+
+    /**
+     * Implements validation via Polymer.IronValidatableBehavior. Considered
+     * valid if `allowEmptySelection` is `true` or it's `false` and there is
+     * a selected value.
+     *
+     * @method validate
+     * @param {string|number} value
+     * @returns `true` if `value` is valid
+     */
+    validate: function(value) {
+      var val = value || this.value;
+      return !!(typeof val === "string" && val) || !this.required;
     }
   });
 </script>

--- a/test/form.html
+++ b/test/form.html
@@ -1,0 +1,111 @@
+<!doctype html>
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <title>paper-radio-group form tests</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+
+    <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+    <script src="../../web-component-tester/browser.js"></script>
+    <script src="../../iron-test-helpers/mock-interactions.js"></script>
+    <link rel="import" href="../../iron-form/iron-form.html">
+    <link rel="import" href="../paper-radio-group.html">
+
+  </head>
+  <body>
+
+    <test-fixture id="FormSerialization">
+      <template>
+        <form is="iron-form">
+          <paper-radio-group name="radioGroup" selected="r1">
+            <paper-radio-button name="r1">r1</paper-radio-button>
+            <paper-radio-button name="r2">r2</paper-radio-button>
+            <paper-radio-button name="r3">r3</paper-radio-button>
+          </paper-radio-group>
+        </form>
+      </template>
+    </test-fixture>
+
+    <test-fixture id="FormValidation">
+      <template>
+        <form is="iron-form">
+          <paper-radio-group name="radioGroup">
+            <paper-radio-button name="r1">r1</paper-radio-button>
+            <paper-radio-button name="r2">r2</paper-radio-button>
+            <paper-radio-button name="r3">r3</paper-radio-button>
+          </paper-radio-group>
+        </form>
+      </template>
+    </test-fixture>
+
+    <test-fixture id="FormValidationAllowEmpty">
+      <template>
+        <form is="iron-form">
+          <paper-radio-group name="radioGroup" allow-empty-selection>
+            <paper-radio-button name="r1">r1</paper-radio-button>
+            <paper-radio-button name="r2">r2</paper-radio-button>
+            <paper-radio-button name="r3">r3</paper-radio-button>
+          </paper-radio-group>
+        </form>
+      </template>
+    </test-fixture>
+
+    <script>
+      suite('defaults', function() {
+        test('group in a form should serialize', function (done) {
+          var f = fixture('FormSerialization');
+          var g = f.querySelector("paper-radio-group");
+
+          // Needs to be async since the underlying iron-selector uses observeNodes.
+          Polymer.Base.async(function() {
+            var serialized = f.serialize();
+            expect(g.selected).to.be.equal("r1");
+            expect(serialized.radioGroup).to.be.equal("r1");
+            expect(Object.keys(serialized).length).to.be.equal(1);
+            done();
+          }, 1);
+        });
+
+        test('group in a form should validate', function (done) {
+          var f = fixture('FormValidation');
+          var g = f.querySelector("paper-radio-group");
+
+          Polymer.Base.async(function() {
+            expect(g.allowEmptySelection).to.not.be.ok;
+            expect(g.selected).to.not.be.ok;
+            expect(f.validate()).to.not.be.ok;
+
+            g.selected = "r1";
+            expect(g.selected).to.be.equal("r1");
+            expect(f.validate()).to.be.ok;
+            done();
+          }, 1);
+        });
+
+        test('group in a form should respect allowing empty selection', function (done) {
+          var f = fixture('FormValidationAllowEmpty');
+          var g = f.querySelector("paper-radio-group");
+
+          Polymer.Base.async(function() {
+            expect(g.selected).to.not.be.ok;
+            expect(f.validate()).to.be.equal(true);
+
+            g.selected = "r1";
+            expect(g.selected).to.be.equal("r1");
+            expect(f.validate()).to.be.equal(true);
+            done();
+          }, 1);
+        });
+      });
+    </script>
+  </body>
+</html>

--- a/test/index.html
+++ b/test/index.html
@@ -16,7 +16,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <script>
       WCT.loadSuites([
         'basic.html',
-        'basic.html?dom=shadow'
+        'basic.html?dom=shadow',
+        'form.html',
+        'form.html?dom=shadow'
       ]);
     </script>
   


### PR DESCRIPTION
This proposed change fixes #66 and fixes #58, by adding support for `IronFormElementBehavior` and `IronFormValidatableBehavior`.

This pull request supersedes pull #67 should the Polymer community agree that `IronFormValidatableBehavior` is a good match for `<paper-radio-button>`.

The end result is that calls to `<iron-form>.serialize()` return a payload that includes a key for each `paper-radio-group` contained within it (in addition to other fields), where the value at that key is the value of `selected` (or, in other words, the value of `attrForSelected` on the selected item).

Implementing `IronFormValidatableBehavior` means that `<iron-form>` elements will also respect `allowEmptySelection` when validating forms that contain `<paper-radio-group>`(s).
- <paper-radio-group> now includes the behaviors mentioned above
- in compliance with `IronFormElementBehavior`, `value` is provided as a synonym of the property `selected`
- in compliance with `IronFormValidatableBehavior`:
  - a new `validate` method exists to validate the value of a
    `<paper-radio-group>`
  - the property `required` now reflects the value of
    `allowEmptySelection`
