### PR TITLE
Disabled radio group should not be in tab order

### DIFF
--- a/paper-radio-group.html
+++ b/paper-radio-group.html
@@ -119,12 +119,6 @@ Custom property | Description | Default
       allowEmptySelection: {
         type: Boolean,
         value: false
-      },
-
-      disabled: {
-        type: Boolean,
-        reflectToAttribute: true,
-        observer: '_onDisableChanged',
       }
     },
 
@@ -185,13 +179,6 @@ Custom property | Description | Default
     _onRightKey: function(event) {
       Polymer.IronMenubarBehaviorImpl._onRightKey.apply(this, arguments);
       this._activateFocusedItem();
-    },
-
-    _onDisableChanged: function(disabled) {
-      if (disabled)
-        this.removeAttribute('tabindex');
-      else
-        this.tabindex = 0;
     }
   });
 </script>

--- a/paper-radio-group.html
+++ b/paper-radio-group.html
@@ -80,7 +80,6 @@ Custom property | Description | Default
 
     hostAttributes: {
       role: 'radiogroup',
-      tabindex: 0
     },
 
     properties: {
@@ -120,6 +119,12 @@ Custom property | Description | Default
       allowEmptySelection: {
         type: Boolean,
         value: false
+      },
+
+      disabled: {
+        type: Boolean,
+        reflectToAttribute: true,
+        observer: '_onDisableChanged',
       }
     },
 
@@ -180,6 +185,13 @@ Custom property | Description | Default
     _onRightKey: function(event) {
       Polymer.IronMenubarBehaviorImpl._onRightKey.apply(this, arguments);
       this._activateFocusedItem();
+    },
+
+    _onDisableChanged: function(disabled) {
+      if (disabled)
+        this.removeAttribute('tabindex');
+      else
+        this.tabindex = 0;
     }
   });
 </script>


### PR DESCRIPTION
This change fixes an issue where a paper-radio-group will focus one of its disabled children if all children are disabled. See: http://crbug.com/642644